### PR TITLE
Add Task for verifying an Environment variable is set

### DIFF
--- a/gluish/common.py
+++ b/gluish/common.py
@@ -90,6 +90,22 @@ class Executable(CommonTask):
     def complete(self):
         return which(self.name) is not None
 
+class EnvironmentVariable(CommonTask):
+    """
+    Checks whether an environment variable is set
+    """
+    name = luigi.Parameter()
+    message = luigi.Parameter(default="")
+
+    def run(self):
+        """ Only run if, task is not complete. """
+        raise RuntimeError('Environment variable %s required.\n%s' % (self.name,
+                           self.message))
+
+    def complete(self):
+        return os.getenv(name) is not None
+
+
 
 class LineCount(CommonTask):
     """ Wrapped wc -l. """


### PR DESCRIPTION
Task for ensuring that an Environment variable exists. Similar to the Executable task in that it checks that the environment is properly set up.