### PR TITLE
Put sqlitebck and MySQL dependency in extras section

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup(name='gluish',
       package_dir={'gluish': 'gluish'},
       install_requires=[
         'BeautifulSoup==3.2.1',
-        'MySQL-python==1.2.5',
         'astroid>=1.0.1',
         'colorama==0.3.3',
         'elasticsearch==1.3.0',
@@ -36,8 +35,11 @@ setup(name='gluish',
         'pytz==2014.4',
         'requests==2.5.1',
         'six==1.9.0',
-        'sqlitebck==1.2.1',
         'urllib3==1.10',
         'wsgiref==0.1.2',
       ],
+      extras_require={
+                      'sqlitebck' : [ 'sqlitebck==1.2.1' ],
+                      'MySQL' : [ 'MySQL-python==1.2.5' ]
+                      }
 )


### PR DESCRIPTION
Change the setup.py to make sqlitebck and MySQL dependencies optional. Clients will need to specify that they want these extras by stating their dependency as gluish[sqlitebck,MySQL]. By the way, now that you removed the elasticsearch tasks, can we remove the dependency on elasticsearch, or is there something left that needs it?
